### PR TITLE
Add methods to interrogate the queue

### DIFF
--- a/EDQueue/EDQueue.h
+++ b/EDQueue/EDQueue.h
@@ -46,6 +46,9 @@ typedef enum {
 
 + (EDQueue *)sharedInstance;
 - (void)enqueueWithData:(id)data forTask:(NSString *)task;
+- (Boolean)jobExistsForTask:(NSString *)task;
+- (Boolean)jobIsActiveForTask:(NSString *)task;
+- (NSDictionary *)nextJobForTask:(NSString *)task;
 - (void)start;
 - (void)stop;
 

--- a/EDQueue/EDQueueStorageEngine.h
+++ b/EDQueue/EDQueueStorageEngine.h
@@ -18,9 +18,11 @@
 @property (retain) FMDatabaseQueue *queue;
 
 - (void)createJob:(id)data forTask:(id)task;
+- (Boolean)jobExistsForTask:(id)task;
 - (void)incrementAttemptForJob:(NSNumber *)jid;
 - (void)removeJob:(NSNumber *)jid;
 - (NSUInteger)fetchJobCount;
 - (NSDictionary *)fetchJob;
+- (NSDictionary *)fetchJobForTask:(id)task;
 
 @end

--- a/EDQueue/EDQueueStorageEngine.m
+++ b/EDQueue/EDQueueStorageEngine.m
@@ -53,6 +53,31 @@
 }
 
 /**
+ * Tells if a job exists for the specified task name.
+ *
+ * @param {NSString} Task name
+ *
+ * @return {BOOL}
+ */
+- (Boolean)jobExistsForTask:(id)task
+{
+    __block Boolean jobExists = NO;
+    
+    [self.queue inDatabase:^(FMDatabase *db) {
+        FMResultSet *rs = [db executeQuery:@"SELECT count(id) AS count FROM queue WHERE task = ?", task];
+        [self databaseHadError:[db hadError] fromDatabase:db];
+        
+        while ([rs next]) {
+            jobExists |= ([rs intForColumn:@"count"] > 0);
+        }
+        
+        [rs close];
+    }];
+    
+    return jobExists;
+}
+
+/**
  * Increments the "attempts" column for a specified job.
  *
  * @param {NSNumber} Job id
@@ -119,13 +144,32 @@
         [self databaseHadError:[db hadError] fromDatabase:db];
         
         while ([rs next]) {
-            job = @{
-                @"id":          [NSNumber numberWithInt:[rs intForColumn:@"id"]],
-                @"task":        [rs stringForColumn:@"task"],
-                @"data":        [NSJSONSerialization JSONObjectWithData:[[rs stringForColumn:@"data"] dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers error:nil],
-                @"attempts":    [NSNumber numberWithInt:[rs intForColumn:@"attempts"]],
-                @"stamp":       [rs stringForColumn:@"stamp"]
-            };
+            job = [self jobFromResultSet:rs];
+        }
+        
+        [rs close];
+    }];
+    
+    return job;
+}
+
+/**
+ * Returns the oldest job for the task from the datastore.
+ *
+ * @param {id} Task label
+ *
+ * @return {NSDictionary}
+ */
+- (NSDictionary *)fetchJobForTask:(id)task
+{
+    __block id job;
+    
+    [self.queue inDatabase:^(FMDatabase *db) {
+        FMResultSet *rs = [db executeQuery:@"SELECT * FROM queue WHERE task = ? ORDER BY id ASC LIMIT 1", task];
+        [self databaseHadError:[db hadError] fromDatabase:db];
+        
+        while ([rs next]) {
+            job = [self jobFromResultSet:rs];
         }
         
         [rs close];
@@ -135,6 +179,18 @@
 }
 
 #pragma mark - Private methods
+
+- (NSDictionary *)jobFromResultSet:(FMResultSet *)rs
+{
+    NSDictionary *job = @{
+        @"id":          [NSNumber numberWithInt:[rs intForColumn:@"id"]],
+        @"task":        [rs stringForColumn:@"task"],
+        @"data":        [NSJSONSerialization JSONObjectWithData:[[rs stringForColumn:@"data"] dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers error:nil],
+        @"attempts":    [NSNumber numberWithInt:[rs intForColumn:@"attempts"]],
+        @"stamp":       [rs stringForColumn:@"stamp"]
+    };
+    return job;
+}
 
 - (Boolean)databaseHadError:(Boolean)flag fromDatabase:(FMDatabase *)db
 {


### PR DESCRIPTION
To know if a job exists for a task, if it's currently active and get the information about the next job for a task.

I needed this to know if a job was currently active for a screen so I could adapt the UI to tell the user that it's still processing. My tasks have unique names that I can recompose to find them in the queue.
