### PR TITLE
Bugfix: stop processing jobs after calling stop

### DIFF
--- a/EDQueue/EDQueue.m
+++ b/EDQueue/EDQueue.m
@@ -144,7 +144,7 @@ NSString *const EDQueueDidDrain = @"EDQueueDidDrain";
 - (void)stop
 {
     if (self.isRunning) {
-        _isRunning = YES;
+        _isRunning = NO;
         [self performSelectorOnMainThread:@selector(postNotification:) withObject:[NSDictionary dictionaryWithObjectsAndKeys:EDQueueDidStop, @"name", nil, @"data", nil] waitUntilDone:false];
     }
 }


### PR DESCRIPTION
To be clear, I have not tested this patch. I was merely reading over the code and noticed this oddity. Perhaps I am not understanding the full picture. But, it seems like _isRunning is the control variable for methods that process jobs. By setting this to `NO` we ensure that we actually stop processing jobs.
