### PR TITLE
Added optional 'runAfter' timestamp to jobs.

### DIFF
--- a/EDQueue/EDQueue.h
+++ b/EDQueue/EDQueue.h
@@ -34,6 +34,8 @@ extern NSString *const EDQueueDidDrain;
 @property (nonatomic) NSUInteger retryLimit;
 
 - (void)enqueueWithData:(id)data forTask:(NSString *)task;
+- (void)enqueueWithData:(id)data forTask:(NSString *)task runAfter:(NSDate*)runAfter;
+
 - (void)start;
 - (void)stop;
 - (void)empty;

--- a/EDQueue/EDQueue.m
+++ b/EDQueue/EDQueue.m
@@ -83,7 +83,28 @@ NSString *const EDQueueDidDrain = @"EDQueueDidDrain";
 }
 
 /**
- * Returns true if a job exists for this task.
+ * Adds a new scheduled job to the queue.
+ *
+ * @param {id} Data
+ * @param {NSString} Task label
+ * @param {NSDate} Run After
+ *
+ * @return {void}
+ */
+- (void)enqueueWithData:(id)data forTask:(NSString *)task runAfter:(NSDate*)runAfter
+{
+    if (!runAfter)
+    {
+        [self enqueueWithData:data forTask:task];
+        return;
+    }
+    
+    if (data == nil) data = @{};
+    [self.engine createJob:data forTask:task runAfter:runAfter];
+    [self tick];
+}
+
+/** * Returns true if a job exists for this task.
  *
  * @param {NSString} Task label
  *

--- a/EDQueue/EDQueueStorageEngine.h
+++ b/EDQueue/EDQueueStorageEngine.h
@@ -14,6 +14,7 @@
 @property (retain) FMDatabaseQueue *queue;
 
 - (void)createJob:(id)data forTask:(id)task;
+- (void)createJob:(id)data forTask:(id)task runAfter:(NSDate*)runAfter;
 - (BOOL)jobExistsForTask:(id)task;
 - (void)incrementAttemptForJob:(NSNumber *)jid;
 - (void)removeJob:(NSNumber *)jid;


### PR DESCRIPTION
Added support to optionally add send a "runAfter" timestamp when creating jobs.  This allows for more efficient scheduling of jobs for many purposes, including the one that I'm using it for...retrying failed communications jobs.