### PR TITLE
Import UIKit, not Foundation.

### DIFF
--- a/EDQueue/EDQueue.h
+++ b/EDQueue/EDQueue.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Andrew Sliwinski. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 typedef NS_ENUM(NSInteger, EDQueueResult) {
     EDQueueResultSuccess = 0,


### PR DESCRIPTION
`EDQueue.h` uses `UIKIT_EXTERN`, but does not import UIKit. Fix this.

In practice, this is/was only an issue for client projects that are trying to get away from precompiled headers -- as the default precompile header import of UIKit would mask this issue.