### PR TITLE
Added initWithPath: to better facilitate multiple queues.

### DIFF
--- a/EDQueue/EDQueue.h
+++ b/EDQueue/EDQueue.h
@@ -26,6 +26,8 @@ extern NSString *const EDQueueDidDrain;
 @interface EDQueue : NSObject
 
 + (EDQueue *)sharedInstance;
++ (NSString *)defaultPath;
+- (id)initWithPath:(NSString *)path;
 
 @property (nonatomic, weak) id<EDQueueDelegate> delegate;
 

--- a/EDQueue/EDQueue.m
+++ b/EDQueue/EDQueue.m
@@ -37,6 +37,11 @@ NSString *const EDQueueDidDrain = @"EDQueueDidDrain";
 
 #pragma mark - Singleton
 
++ (NSString *)defaultPath
+{
+    return @"edqueue_0.5.0d.db";
+}
+
 + (EDQueue *)sharedInstance
 {
     static EDQueue *singleton = nil;
@@ -49,11 +54,17 @@ NSString *const EDQueueDidDrain = @"EDQueueDidDrain";
 
 #pragma mark - Init
 
-- (id)init
+- (id)init {
+    self = [self initWithPath:[self.class defaultPath]];
+    return self;
+}
+
+- (id)initWithPath:(NSString *)path
 {
+    NSAssert(path != nil, @"Path is required and may not be null");
     self = [super init];
     if (self) {
-        _engine     = [[EDQueueStorageEngine alloc] init];
+        _engine     = [[EDQueueStorageEngine alloc] initWithPath:path];
         _retryLimit = 4;
     }
     return self;

--- a/EDQueue/EDQueueStorageEngine.h
+++ b/EDQueue/EDQueueStorageEngine.h
@@ -13,6 +13,7 @@
 
 @property (retain) FMDatabaseQueue *queue;
 
+- (id)initWithPath:(NSString *)inputPath;
 - (void)createJob:(id)data forTask:(id)task;
 - (BOOL)jobExistsForTask:(id)task;
 - (void)incrementAttemptForJob:(NSNumber *)jid;

--- a/EDQueue/EDQueueStorageEngine.m
+++ b/EDQueue/EDQueueStorageEngine.m
@@ -17,14 +17,14 @@
 
 #pragma mark - Init
 
-- (id)init
+- (id)initWithPath:(NSString *)inputPath
 {
     self = [super init];
     if (self) {
         // Database path
         NSArray *paths                  = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask,YES);
         NSString *documentsDirectory    = [paths objectAtIndex:0];
-        NSString *path                  = [documentsDirectory stringByAppendingPathComponent:@"edqueue_0.5.0d.db"];
+        NSString *path                  = [documentsDirectory stringByAppendingPathComponent:inputPath];
         
         // Allocate the queue
         _queue                          = [[FMDatabaseQueue alloc] initWithPath:path];


### PR DESCRIPTION
EDQueue doesn't support assigning priorities to jobs. The easiest workaround IMO is multiple queues, where the "low priority" jobs (which are assumed to be more numerous) are put into the sharedInstance() queue, and the "high priority" jobs (which are assumed to be less numerous) are put into a custom instance with a different path.