### PR TITLE
Add ability to getAllJobs

### DIFF
--- a/EDQueue/EDQueue.h
+++ b/EDQueue/EDQueue.h
@@ -41,6 +41,7 @@ extern NSString *const EDQueueDidDrain;
 - (BOOL)jobExistsForTask:(NSString *)task;
 - (BOOL)jobIsActiveForTask:(NSString *)task;
 - (NSDictionary *)nextJobForTask:(NSString *)task;
+- (NSArray *) getAllJobs;
 
 @end
 

--- a/EDQueue/EDQueue.m
+++ b/EDQueue/EDQueue.m
@@ -121,6 +121,10 @@ NSString *const EDQueueDidDrain = @"EDQueueDidDrain";
     return nextJobForTask;
 }
 
+- (NSArray *) getAllJobs{
+  return [self.engine getAllJobs];
+}
+
 /**
  * Starts the queue.
  *

--- a/EDQueue/EDQueueStorageEngine.h
+++ b/EDQueue/EDQueueStorageEngine.h
@@ -21,5 +21,6 @@
 - (NSUInteger)fetchJobCount;
 - (NSDictionary *)fetchJob;
 - (NSDictionary *)fetchJobForTask:(id)task;
+- (NSArray *)getAllJobs;
 
 @end

--- a/EDQueue/EDQueueStorageEngine.m
+++ b/EDQueue/EDQueueStorageEngine.m
@@ -163,7 +163,7 @@
     __block id job;
     
     [self.queue inDatabase:^(FMDatabase *db) {
-        FMResultSet *rs = [db executeQuery:@"SELECT * FROM queue ORDER BY id ASC LIMIT 1"];
+        FMResultSet *rs = [db executeQuery:@"SELECT * FROM queue ORDER BY attempts DESC, id ASC LIMIT 1"];
         [self _databaseHadError:[db hadError] fromDatabase:db];
         
         while ([rs next]) {

--- a/EDQueue/EDQueueStorageEngine.m
+++ b/EDQueue/EDQueueStorageEngine.m
@@ -201,6 +201,21 @@
     return job;
 }
 
+- (NSArray *)getAllJobs
+{
+  __block id jobs = [[NSMutableArray alloc] init];
+  [self.queue inDatabase:^(FMDatabase *db) {
+    FMResultSet *rs = [db executeQuery:@"SELECT * FROM queue ORDER BY id ASC"];
+    [self _databaseHadError:[db hadError] fromDatabase:db];
+    while ([rs next]) {
+      NSDictionary *job = [self _jobFromResultSet:rs];
+      if (job) [jobs addObject:job];
+    }
+    [rs close];
+  }];
+  return jobs;
+}
+
 #pragma mark - Private methods
 
 - (NSDictionary *)_jobFromResultSet:(FMResultSet *)rs

--- a/EDQueue/EDQueueStorageEngine.m
+++ b/EDQueue/EDQueueStorageEngine.m
@@ -163,7 +163,7 @@
     __block id job;
     
     [self.queue inDatabase:^(FMDatabase *db) {
-        FMResultSet *rs = [db executeQuery:@"SELECT * FROM queue ORDER BY attempts DESC, id ASC LIMIT 1"];
+        FMResultSet *rs = [db executeQuery:@"SELECT * FROM queue ORDER BY attempts ASC, id ASC LIMIT 1"];
         [self _databaseHadError:[db hadError] fromDatabase:db];
         
         while ([rs next]) {


### PR DESCRIPTION
This change adds the ability to get all the jobs in the queue.
We find this useful for generating diagnostic report for debugging purpose. Previously we had jobs that never completed and this helps us to debug production issues remotely.
